### PR TITLE
fix: Fix raspbian issue

### DIFF
--- a/sdwire/backend/device/sdwire.py
+++ b/sdwire/backend/device/sdwire.py
@@ -17,7 +17,7 @@ class SDWire(USBDevice):
                 self.dev_string.device_path != sibling.device_path
                 and sibling.device_type == "disk"
             ):
-                self.__block_dev = f"/dev/{sibling.device_path.split("/")[-1]}"
+                self.__block_dev = f"/dev/{sibling.device_path.split('/')[-1]}"
                 break
 
     def switch_ts(self):

--- a/sdwire/backend/device/sdwirec.py
+++ b/sdwire/backend/device/sdwirec.py
@@ -18,7 +18,7 @@ class SDWireC(USBDevice):
                         d.device_path != sibling.device_path
                         and sibling.device_type == "disk"
                     ):
-                        self.__block_dev = f"/dev/{sibling.device_path.split("/")[-1]}"
+                        self.__block_dev = f"/dev/{sibling.device_path.split('/')[-1]}"
                         break
                 break
 


### PR DESCRIPTION
On website :

```
# For Rasbian/Debian users please use apt instead of pip directly
echo -e "deb https://ppa.launchpadcontent.net/tchavadar/badgerd/ubuntu noble main" | sudo tee -a /etc/apt/sources.list.d/badgerd.list
sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys B35AA5B4E400B24A
sudo apt install python3-sdwire
# Do not hesitate to open issue in our github repo: https://github.com/Badger-Embedded/sdwire-cli/issues
```
**### `sudo apt update` <--- we need to add this there!**

Fixes:
https://github.com/Badger-Embedded/sdwire-cli/issues/13

There is some places on backend/detect.py like that were just found on apt source but not on current gh-repo.
```
  File "/usr/lib/python3/dist-packages/sdwire/backend/detect.py", line 77
    serial = f"{device.get("ID_USB_SERIAL_SHORT")}:{bus}.{address}
```

This PR just fix the 2 remaining places I missed to get sucess on rpi.

Other details:
```
pi@raspberrypi:~/Documents $ sudo nano /usr/lib/python3/dist-packages/sdwire/backend/device/sdwire.py 
pi@raspberrypi:~/Documents $ sudo apt-mark hold python3-sdwire
python3-sdwire was already set on hold.
pi@raspberrypi:~/Documents $ sudo nano /usr/lib/python3/dist-packages/sdwire/backend/device/sdwirec.py 
pi@raspberrypi:~/Documents $ sudo apt install -f
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
0 upgraded, 0 newly installed, 0 to remove and 2 not upgraded.
1 not fully installed or removed.
After this operation, 0 B of additional disk space will be used.
Setting up python3-sdwire (0.2.3-0badgerd1) ...
pi@raspberrypi:~/Documents $ sdwire status
Usage: sdwire [OPTIONS] COMMAND [ARGS]...
Try 'sdwire --help' for help.

Error: No such command 'status'.
pi@raspberrypi:~/Documents $ sdwire list
Serial                  Product Info            Block Dev
20120501030900000:2.2   [0bda::0316]            /dev/sda
```
